### PR TITLE
CommitmentMessageId (de)serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "blake3",
  "clap",
  "colored",
+ "derivative",
  "dotenv",
  "esplora-client",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.5.11"
 colored = "2.0.0"
 itertools = "0.13.0"
 serde-big-array = "0.5.1"
+derivative = "2.2.0"
 
 [dev-dependencies]
 num-bigint = { version = "0.4.4", features = ["rand"] }

--- a/src/bridge/connectors/connector_c.rs
+++ b/src/bridge/connectors/connector_c.rs
@@ -76,7 +76,7 @@ impl ConnectorC {
             .map(|(k, v)| {
                 (
                     match k {
-                        CommitmentMessageId::Groth16IntermediateValues((name, _)) => name,
+                        CommitmentMessageId::Groth16IntermediateValues(name, _) => name,
                         _ => String::new(),
                     },
                     v,
@@ -133,7 +133,7 @@ pub fn generate_assert_leaves(
         .map(|(k, v)| {
             (
                 match k {
-                    CommitmentMessageId::Groth16IntermediateValues((name, _)) => name,
+                    CommitmentMessageId::Groth16IntermediateValues(name, _) => name,
                     _ => String::new(),
                 },
                 v,

--- a/src/bridge/connectors/connector_e.rs
+++ b/src/bridge/connectors/connector_e.rs
@@ -39,7 +39,7 @@ impl TaprootConnector for ConnectorE {
         let mut script = script! {};
         for (message, pk) in self.commitment_public_keys.iter().rev() {
             match message {
-                CommitmentMessageId::Groth16IntermediateValues((_, size)) => {
+                CommitmentMessageId::Groth16IntermediateValues(_, size) => {
                     script = script.push_script(
                         script! {
                             {winternitz_message_checksig_verify(pk, *size)}

--- a/src/bridge/transactions/assert_transactions/utils.rs
+++ b/src/bridge/transactions/assert_transactions/utils.rs
@@ -73,7 +73,7 @@ pub fn sign_assert_tx_with_groth16_proof(
         .map(|(k, v)| {
             (
                 match k {
-                    CommitmentMessageId::Groth16IntermediateValues((name, _)) => name,
+                    CommitmentMessageId::Groth16IntermediateValues(name, _) => name,
                     _ => String::new(),
                 },
                 v,
@@ -102,7 +102,7 @@ pub fn sign_assert_tx_with_groth16_proof(
     for pks in commit1_publickeys {
         let mut witness = vec![];
         for (message, _) in pks {
-            if let CommitmentMessageId::Groth16IntermediateValues((name, _)) = message {
+            if let CommitmentMessageId::Groth16IntermediateValues(name, _) = message {
                 witness.append(&mut bridge_assigner.get_witness(elements.get(&name).unwrap()));
             }
         }
@@ -112,7 +112,7 @@ pub fn sign_assert_tx_with_groth16_proof(
     for pks in commit2_publickeys {
         let mut witness = vec![];
         for (message, _) in pks {
-            if let CommitmentMessageId::Groth16IntermediateValues((name, _)) = message {
+            if let CommitmentMessageId::Groth16IntermediateValues(name, _) = message {
                 witness.append(&mut bridge_assigner.get_witness(elements.get(&name).unwrap()));
             }
         }
@@ -138,7 +138,7 @@ pub fn groth16_commitment_secrets_to_public_keys(
     let mut connector_e2_commitment_public_keys = vec![];
 
     for (message_id, secret) in commitment_secrets.iter() {
-        if let CommitmentMessageId::Groth16IntermediateValues((_, _)) = message_id {
+        if let CommitmentMessageId::Groth16IntermediateValues(_, _) = message_id {
             let pushing_keys =
                 if connector_e1_commitment_public_keys.len() < connectors_e_of_transaction {
                     &mut connector_e1_commitment_public_keys

--- a/tests/bridge/setup.rs
+++ b/tests/bridge/setup.rs
@@ -280,7 +280,7 @@ fn get_test_commitment_secrets() -> HashMap<CommitmentMessageId, WinternitzSecre
     // split variable to different connectors
     for (v, size) in all_variables {
         commitment_map.insert(
-            CommitmentMessageId::Groth16IntermediateValues((v, size)),
+            CommitmentMessageId::Groth16IntermediateValues(v, size),
             WinternitzSecret::new(size),
         );
     }


### PR DESCRIPTION
Found this bug in `test_peg_out_graph_serialization`

> called `Result::unwrap()` on an `Err` value: Error("key must be a string", line: 0, column: 0)


Now (de)serialization errors are no longer appearing, but need follow up investigation for `Eq` derive on peg out objects

> assertion failed: peg_out_graph == deserialized_peg_out_graph

----------------------
Update:  8f7309b fixes PartialEq derive by ignoring `lock_scripts_generator_wrapper`