### PR TITLE
Reduce default block interval on regtest

### DIFF
--- a/regtest/block-generator.sh
+++ b/regtest/block-generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-        interval=40
+        interval=8
 else
         interval=$1
 fi


### PR DESCRIPTION
Change default block interval on regtest from 40 to 8 seconds