### PR TITLE
Cache lock scripts  locally for ConnectorC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools",
+ "lz4_flex",
  "musig2",
  "num-traits",
  "openssh",
@@ -3339,6 +3340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -5456,6 +5466,16 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -40,6 +40,7 @@ ark-serialize.workspace = true
 ark-ff.workspace = true
 ark-std.workspace = true
 secp256k1.workspace = true
+lz4_flex = "0.11.3"
 
 [profile.dev]
 opt-level = 3

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -16,12 +16,7 @@ use std::{
 use crate::{
     commitments::CommitmentMessageId,
     common::ZkProofVerifyingKey,
-    connectors::{
-        base::TaprootConnector,
-        connector_0::Connector0,
-        connector_c::{generate_assert_leaves, LockScriptsGenerator},
-        connector_z::ConnectorZ,
-    },
+    connectors::{base::TaprootConnector, connector_0::Connector0, connector_z::ConnectorZ},
 };
 use crate::{
     constants::DestinationNetwork,
@@ -764,7 +759,6 @@ impl BitVMClient {
                         peg_in_graph_id,
                         input,
                         CommitmentMessageId::generate_commitment_secrets(),
-                        generate_assert_leaves,
                     )
                     .await;
                 }
@@ -901,7 +895,6 @@ impl BitVMClient {
         peg_in_graph_id: &str,
         peg_out_confirm_input: Input,
         commitment_secrets: HashMap<CommitmentMessageId, WinternitzSecret>,
-        lock_scripts_generator: LockScriptsGenerator,
     ) -> String {
         if self.operator_context.is_none() {
             panic!("Operator context must be initialized");
@@ -930,7 +923,6 @@ impl BitVMClient {
             peg_in_graph,
             peg_out_confirm_input,
             &commitment_secrets,
-            lock_scripts_generator,
         );
 
         self.private_data.commitment_secrets = HashMap::from([(

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -10,7 +10,9 @@ use crate::{
     connectors::base::*,
     error::{ChunkerError, Error, GraphError},
     transactions::base::Input,
-    utils::{read_cache, remove_script_and_control_block_from_witness, write_cache},
+    utils::{
+        cleanup_cache_files, read_cache, remove_script_and_control_block_from_witness, write_cache,
+    },
 };
 use bitcoin::{
     hashes::{hash160, Hash},
@@ -47,6 +49,7 @@ pub struct DisproveLeaf {
 
 // TODO: use the same cache location as in client
 const CACHE_LOCATION: &str = "bridge_data/cache/";
+const MAX_CACHE_FILES: u32 = 20;
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct ConnectorC {
@@ -83,6 +86,8 @@ impl Serialize for ConnectorC {
         } else {
             write_cache(lock_script_cache_path, &self.lock_scripts).map_err(SerError::custom)?;
         }
+
+        cleanup_cache_files("lock-scripts-", CACHE_LOCATION, MAX_CACHE_FILES);
 
         c.end()
     }

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -45,6 +45,7 @@ pub struct DisproveLeaf {
     pub unlock: UnlockWitness,
 }
 
+// TODO: use the same cache location as in client
 const CACHE_LOCATION: &str = "bridge_data/cache/";
 
 #[derive(Eq, PartialEq, Clone)]
@@ -75,9 +76,13 @@ impl Serialize for ConnectorC {
         c.serialize_field("lock_scripts", &cache_id)?;
 
         let lock_script_cache_file_path =
-            &format!("{}lock-script-{}.json", CACHE_LOCATION, &cache_id);
+            &format!("{}lock-scripts-{}.json", CACHE_LOCATION, &cache_id);
         let lock_script_cache_path = Path::new(&lock_script_cache_file_path);
-        write_cache(lock_script_cache_path, &self.lock_scripts).map_err(SerError::custom)?;
+        if lock_script_cache_path.exists() {
+            println!("Lock script cache exists: {}", &cache_id);
+        } else {
+            write_cache(lock_script_cache_path, &self.lock_scripts).map_err(SerError::custom)?;
+        }
 
         c.end()
     }
@@ -157,7 +162,7 @@ impl ConnectorC {
     ) -> Self {
         let mut lock_scripts_cache = None;
         if let Some(cache_id) = lock_scripts_cache_id {
-            let file = &format!("{}lock-script-{}.json", CACHE_LOCATION, &cache_id);
+            let file = &format!("{}lock-scripts-{}.json", CACHE_LOCATION, &cache_id);
             lock_scripts_cache = read_cache::<Vec<ScriptBuf>>(Path::new(&file)).ok();
         }
 

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -1,20 +1,29 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    fmt::{Formatter, Result as FmtResult},
+    path::Path,
+};
 
 use crate::{
     commitments::CommitmentMessageId,
     common::ZkProofVerifyingKey,
     connectors::base::*,
-    error::{ChunkerError, Error},
+    error::{ChunkerError, Error, GraphError},
     transactions::base::Input,
-    utils::remove_script_and_control_block_from_witness,
+    utils::{read_cache, remove_script_and_control_block_from_witness, write_cache},
 };
 use bitcoin::{
+    hashes::{hash160, Hash},
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, Transaction, TxIn, XOnlyPublicKey,
 };
 use num_traits::ToPrimitive;
 use secp256k1::SECP256K1;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de,
+    ser::{Error as SerError, SerializeStruct},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use bitvm::{
     chunker::{
@@ -36,10 +45,9 @@ pub struct DisproveLeaf {
     pub unlock: UnlockWitness,
 }
 
-pub type LockScriptsGenerator =
-    fn(&BTreeMap<CommitmentMessageId, WinternitzPublicKey>) -> Vec<ScriptBuf>;
+const CACHE_LOCATION: &str = "bridge_data/cache/";
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub struct ConnectorC {
     pub network: Network,
     pub operator_taproot_public_key: XOnlyPublicKey,
@@ -47,20 +55,118 @@ pub struct ConnectorC {
     commitment_public_keys: BTreeMap<CommitmentMessageId, WinternitzPublicKey>,
 }
 
+impl Serialize for ConnectorC {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut c = s.serialize_struct("ConnectorC", 4)?;
+        c.serialize_field("network", &self.network.to_string())?;
+        c.serialize_field(
+            "operator_taproot_public_key",
+            &self.operator_taproot_public_key.to_string(),
+        )?;
+        c.serialize_field(
+            "commitment_public_keys",
+            &self.commitment_public_keys.clone(),
+        )?;
+
+        let cache_id = Self::cache_id(&self.commitment_public_keys).map_err(SerError::custom)?;
+        c.serialize_field("lock_scripts", &cache_id)?;
+
+        let lock_script_cache_file_path =
+            &format!("{}lock-script-{}.json", CACHE_LOCATION, &cache_id);
+        let lock_script_cache_path = Path::new(&lock_script_cache_file_path);
+        write_cache(lock_script_cache_path, &self.lock_scripts).map_err(SerError::custom)?;
+
+        c.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ConnectorC {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct JsonConnectorCVisitor;
+        impl<'de> de::Visitor<'de> for JsonConnectorCVisitor {
+            type Value = ConnectorC;
+
+            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                formatter.write_str("a string containing ConnectorC data")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut operator_taproot_public_key = None;
+                let mut commitment_public_keys = None;
+                let mut network = None;
+                let mut lock_scripts_cache_id = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        "network" => network = Some(map.next_value()?),
+                        "operator_taproot_public_key" => {
+                            operator_taproot_public_key = Some(map.next_value()?)
+                        }
+                        "commitment_public_keys" => {
+                            commitment_public_keys = Some(map.next_value()?)
+                        }
+                        "lock_scripts" => lock_scripts_cache_id = Some(map.next_value()?),
+                        _ => (),
+                    }
+                }
+
+                match (network, operator_taproot_public_key, commitment_public_keys) {
+                    (
+                        Some(network),
+                        Some(operator_taproot_public_key),
+                        Some(commitment_public_keys),
+                    ) => Ok(ConnectorC::new(
+                        network,
+                        &operator_taproot_public_key,
+                        &commitment_public_keys,
+                        lock_scripts_cache_id,
+                    )),
+                    _ => Err(de::Error::custom("Invalid ConnectorC data")),
+                }
+            }
+        }
+
+        d.deserialize_struct(
+            "ConnectorC",
+            &[
+                "network",
+                "operator_taproot_public_key",
+                "commitment_public_keys",
+                "lock_scripts",
+            ],
+            JsonConnectorCVisitor,
+        )
+    }
+}
+
 impl ConnectorC {
     pub fn new(
         network: Network,
         operator_taproot_public_key: &XOnlyPublicKey,
         commitment_public_keys: &BTreeMap<CommitmentMessageId, WinternitzPublicKey>,
-        lock_scripts_generator: LockScriptsGenerator,
-        lock_scripts_cache: Option<Vec<ScriptBuf>>,
+        lock_scripts_cache_id: Option<String>,
     ) -> Self {
+        let mut lock_scripts_cache = None;
+        if let Some(cache_id) = lock_scripts_cache_id {
+            let file = &format!("{}lock-script-{}.json", CACHE_LOCATION, &cache_id);
+            lock_scripts_cache = read_cache::<Vec<ScriptBuf>>(Path::new(&file)).ok();
+        }
+
         ConnectorC {
             network,
             operator_taproot_public_key: *operator_taproot_public_key,
             lock_scripts: match lock_scripts_cache {
                 Some(lock_scripts) => lock_scripts,
-                None => lock_scripts_generator(commitment_public_keys),
+                None => generate_assert_leaves(commitment_public_keys),
             },
             commitment_public_keys: commitment_public_keys.clone(),
         }
@@ -94,6 +200,18 @@ impl ConnectorC {
             vk.clone(),
         )
         .ok_or(Error::Chunker(ChunkerError::InvalidProof))
+    }
+
+    pub fn cache_id(
+        commitment_public_keys: &BTreeMap<CommitmentMessageId, WinternitzPublicKey>,
+    ) -> Result<String, Error> {
+        let first_winternitz_public_key = commitment_public_keys
+            .iter()
+            .next()
+            .ok_or(Error::Graph(GraphError::ConnectorCCommitsPublicKeyEmpty))?
+            .1;
+        let hash = hash160::Hash::hash(&first_winternitz_public_key.public_key.as_flattened());
+        Ok(hex::encode(hash))
     }
 }
 

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -36,6 +36,7 @@ pub enum GraphError {
     PrecedingTxNotConfirmed(Vec<NamedTx>),
     PrecedingTxTimelockNotMet(NamedTx),
     WitnessNotGenerated(CommitmentMessageId),
+    ConnectorCCommitsPublicKeyEmpty,
 }
 
 #[derive(Debug)]

--- a/bridge/src/utils.rs
+++ b/bridge/src/utils.rs
@@ -1,7 +1,13 @@
+use std::{
+    io::{Read, Write},
+    path::PathBuf,
+};
+
 use bitcoin::Network;
 use bitcoin_script::{script, Script};
 
 use bitvm::{bigint::BigIntImpl, pseudo::NMUL};
+use lz4_flex::block::{compress_prepend_size, decompress_size_prepended};
 use serde::{Deserialize, Serialize};
 
 const NUM_BLOCKS_REGTEST: u32 = 3;
@@ -102,6 +108,28 @@ pub fn sb_hash_from_bytes() -> Script {
     }
 }
 
+pub fn cleanup_cache_files(prefix: &str, cache_location: &str, max_cache_files: u32) {
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(cache_location)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_str().unwrap_or("").starts_with(prefix))
+        .map(|entry| entry.path())
+        .collect();
+
+    paths.sort_by_key(|path| {
+        std::fs::metadata(path)
+            .and_then(|m| m.modified())
+            .unwrap_or_else(|_| std::time::SystemTime::now())
+    });
+
+    if paths.len() >= max_cache_files as usize {
+        if let Some(oldest) = paths.first() {
+            std::fs::remove_file(oldest).expect("Failed to delete the oldest cache file");
+            println!("Deleted oldest cache file: {:?}", oldest);
+        }
+    }
+}
+
 pub fn write_cache(file_path: &std::path::Path, data: &impl Serialize) -> std::io::Result<()> {
     println!("Writing cache to {}...", file_path.to_str().unwrap());
     let path_only = file_path
@@ -112,9 +140,13 @@ pub fn write_cache(file_path: &std::path::Path, data: &impl Serialize) -> std::i
         std::fs::create_dir_all(path_only)?;
     }
     let file = std::fs::File::create(file_path)?;
-    let file = std::io::BufWriter::new(file);
+    let mut file = std::io::BufWriter::new(file);
 
-    serde_json::to_writer(file, data).map_err(std::io::Error::from)
+    let compressed = compress_prepend_size(&serde_json::to_vec(data).unwrap());
+
+    file.write_all(&compressed)?;
+
+    Ok(())
 }
 
 pub fn read_cache<T>(file_path: &std::path::Path) -> std::io::Result<T>
@@ -123,7 +155,16 @@ where
 {
     println!("Reading cache from {}...", file_path.to_str().unwrap());
     let file = std::fs::File::open(file_path)?;
-    let file = std::io::BufReader::new(file);
+    let mut file = std::io::BufReader::new(file);
 
-    serde_json::from_reader(file).map_err(std::io::Error::from)
+    let mut compressed_data = Vec::new();
+    file.read_to_end(&mut compressed_data)?;
+
+    let decompressed_data = decompress_size_prepended(&compressed_data)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let deserialized: T = serde_json::from_slice(&decompressed_data)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    Ok(deserialized)
 }

--- a/bridge/tests/bridge/client/fee.rs
+++ b/bridge/tests/bridge/client/fee.rs
@@ -32,8 +32,7 @@ use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
         check_tx_output_sum, find_peg_in_graph_by_peg_out, generate_stub_outpoint,
-        get_lock_scripts_cached, get_reward_amount, random_hex, wait_for_confirmation,
-        wait_timelock_expiry,
+        get_reward_amount, random_hex, wait_for_confirmation, wait_timelock_expiry,
     },
     mock::chain::mock::MockAdaptor,
     setup::{setup_test, INITIAL_AMOUNT, ONE_HUNDRED},
@@ -155,7 +154,6 @@ async fn test_peg_out_fees() {
                 amount: peg_out_confirm_input_amount,
             },
             config.commitment_secrets,
-            get_lock_scripts_cached,
         )
         .await;
 

--- a/bridge/tests/bridge/client/merge.rs
+++ b/bridge/tests/bridge/client/merge.rs
@@ -7,10 +7,7 @@ use bridge::{
     transactions::base::Input,
 };
 
-use crate::bridge::{
-    helper::get_lock_scripts_cached,
-    setup::{setup_test, INITIAL_AMOUNT},
-};
+use crate::bridge::setup::{setup_test, INITIAL_AMOUNT};
 
 #[tokio::test]
 // TODO: test merging signatures after Musig2 feature is ready
@@ -79,7 +76,6 @@ async fn setup_and_create_graphs() -> (BitVMClient, PegInGraph, PegOutGraph) {
                 amount,
             },
             config.commitment_secrets.clone(),
-            get_lock_scripts_cached,
         )
         .await;
 
@@ -100,7 +96,6 @@ async fn setup_and_create_graphs() -> (BitVMClient, PegInGraph, PegOutGraph) {
             amount,
         },
         &config.commitment_secrets,
-        get_lock_scripts_cached,
     );
 
     (config.client_0, new_peg_in_graph, new_peg_out_graph)

--- a/bridge/tests/bridge/client/musig2_peg_out.rs
+++ b/bridge/tests/bridge/client/musig2_peg_out.rs
@@ -25,9 +25,7 @@ use tokio::time::sleep;
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{
-        find_peg_in_graph_by_peg_out, generate_stub_outpoint, get_lock_scripts_cached, TX_WAIT_TIME,
-    },
+    helper::{find_peg_in_graph_by_peg_out, generate_stub_outpoint, TX_WAIT_TIME},
     mock::chain::mock::MockAdaptor,
     setup::{setup_test, INITIAL_AMOUNT},
 };
@@ -465,7 +463,6 @@ async fn create_peg_out_graph() -> (
                 amount: kick_off_input_amount,
             },
             config.commitment_secrets,
-            get_lock_scripts_cached,
         )
         .await;
 

--- a/bridge/tests/bridge/client/sync.rs
+++ b/bridge/tests/bridge/client/sync.rs
@@ -7,7 +7,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{generate_stub_outpoint, get_lock_scripts_cached},
+    helper::generate_stub_outpoint,
     setup::{setup_test, INITIAL_AMOUNT},
 };
 
@@ -29,11 +29,13 @@ async fn test_sync() {
 
     let outpoint = generate_stub_outpoint(&config.client_0, &address, amount).await;
 
+    println!("Creating peg in graph ...");
     let peg_in_graph_id = config
         .client_0
         .create_peg_in_graph(Input { outpoint, amount }, &config.depositor_evm_address)
         .await;
 
+    println!("Creating peg out graph ...");
     config
         .client_0
         .create_peg_out_graph(
@@ -51,7 +53,6 @@ async fn test_sync() {
                 amount,
             },
             config.commitment_secrets,
-            get_lock_scripts_cached,
         )
         .await;
 

--- a/bridge/tests/bridge/client/validate.rs
+++ b/bridge/tests/bridge/client/validate.rs
@@ -9,10 +9,7 @@ use bridge::{
     transactions::{base::Input, pre_signed::PreSignedTransaction},
 };
 
-use crate::bridge::{
-    helper::get_lock_scripts_cached,
-    setup::{setup_test, INITIAL_AMOUNT},
-};
+use crate::bridge::setup::{setup_test, INITIAL_AMOUNT};
 
 #[tokio::test]
 async fn test_validate_success() {
@@ -130,7 +127,6 @@ async fn setup_and_create_graphs() -> (BitVMClientPublicData, OutPoint) {
             amount: amount_0,
         },
         &config.commitment_secrets,
-        get_lock_scripts_cached,
     );
 
     let data = BitVMClientPublicData {

--- a/bridge/tests/bridge/e2e/e2e_l2_ui.rs
+++ b/bridge/tests/bridge/e2e/e2e_l2_ui.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{find_peg_out_graph, generate_stub_outpoint, get_lock_scripts_cached, TX_WAIT_TIME},
+    helper::{find_peg_out_graph, generate_stub_outpoint, TX_WAIT_TIME},
     setup::{setup_test, INITIAL_AMOUNT},
 };
 use bitcoin::{Address, Amount};
@@ -217,7 +217,6 @@ async fn create_graph() -> (
                 amount: kick_off_input_amount,
             },
             config.commitment_secrets,
-            get_lock_scripts_cached,
         )
         .await;
 

--- a/bridge/tests/bridge/serialization/peg_out_graph.rs
+++ b/bridge/tests/bridge/serialization/peg_out_graph.rs
@@ -1,11 +1,7 @@
 use bitcoin::{Address, Amount};
 
 use bridge::{
-    graphs::{
-        base::PEG_OUT_FEE_FOR_TAKE_1,
-        peg_in::PegInGraph,
-        peg_out::{LockScriptsGeneratorWrapper, PegOutGraph},
-    },
+    graphs::{base::PEG_OUT_FEE_FOR_TAKE_1, peg_in::PegInGraph, peg_out::PegOutGraph},
     scripts::generate_pay_to_pubkey_script_address,
     serialization::{deserialize, serialize},
     transactions::base::{Input, MIN_RELAY_FEE_PEG_IN_CONFIRM},
@@ -13,7 +9,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{generate_stub_outpoint, get_lock_scripts_cached, get_reward_amount},
+    helper::{generate_stub_outpoint, get_reward_amount},
     setup::{setup_test, ONE_HUNDRED},
 };
 
@@ -61,13 +57,10 @@ async fn test_peg_out_graph_serialization() {
             amount: kick_off_amount,
         },
         &config.commitment_secrets,
-        get_lock_scripts_cached,
     );
 
     let json = serialize(&peg_out_graph);
     assert!(!json.is_empty());
-    let mut deserialized_peg_out_graph = deserialize::<PegOutGraph>(&json);
-    deserialized_peg_out_graph.lock_scripts_generator_wrapper =
-        LockScriptsGeneratorWrapper(get_lock_scripts_cached);
+    let deserialized_peg_out_graph = deserialize::<PegOutGraph>(&json);
     assert!(peg_out_graph == deserialized_peg_out_graph);
 }

--- a/bridge/tests/bridge/setup.rs
+++ b/bridge/tests/bridge/setup.rs
@@ -374,7 +374,7 @@ fn get_test_commitment_secrets() -> HashMap<CommitmentMessageId, WinternitzSecre
     for (v, size) in all_variables {
         commitment_map.insert(
             CommitmentMessageId::Groth16IntermediateValues((v, size)),
-            WinternitzSecret::new(size),
+            generate_test_winternitz_secret(5, size),
         );
     }
     commitment_map

--- a/bridge/tests/bridge/setup.rs
+++ b/bridge/tests/bridge/setup.rs
@@ -137,11 +137,7 @@ pub async fn setup_test_full() -> SetupConfigFull {
         &connector_e2_commitment_public_keys,
     );
 
-    // TODO: investigate why mock-up winternitz public key is not the same
-    let winternitz = commitment_public_keys.iter().next().unwrap().1;
-    let cache_id = hex::encode(winternitz.public_key.as_flattened());
-    println!("lock script cache id: {}", cache_id);
-
+    let cache_id = ConnectorC::cache_id(&commitment_public_keys).unwrap();
     let connector_c = ConnectorC::new(
         config.network,
         &config.operator_context.operator_taproot_public_key,

--- a/bridge/tests/bridge/setup.rs
+++ b/bridge/tests/bridge/setup.rs
@@ -4,7 +4,6 @@ use bitcoin::{Network, PublicKey};
 
 use crate::bridge::helper::{
     get_correct_proof, get_incorrect_proof, get_intermediate_variables_cached,
-    get_lock_scripts_cached,
 };
 use bitvm::{
     chunker::disprove_execution::RawProof,
@@ -138,12 +137,16 @@ pub async fn setup_test_full() -> SetupConfigFull {
         &connector_e2_commitment_public_keys,
     );
 
+    // TODO: investigate why mock-up winternitz public key is not the same
+    let winternitz = commitment_public_keys.iter().next().unwrap().1;
+    let cache_id = hex::encode(winternitz.public_key.as_flattened());
+    println!("lock script cache id: {}", cache_id);
+
     let connector_c = ConnectorC::new(
         config.network,
         &config.operator_context.operator_taproot_public_key,
         &commitment_public_keys,
-        get_lock_scripts_cached,
-        None,
+        Some(cache_id),
     );
 
     SetupConfigFull {

--- a/bridge/tests/bridge/validate/validate.rs
+++ b/bridge/tests/bridge/validate/validate.rs
@@ -8,10 +8,7 @@ use bridge::{
     transactions::{base::Input, pre_signed::PreSignedTransaction},
 };
 
-use crate::bridge::{
-    helper::get_lock_scripts_cached,
-    setup::{setup_test, INITIAL_AMOUNT},
-};
+use crate::bridge::setup::{setup_test, INITIAL_AMOUNT};
 
 #[tokio::test]
 async fn test_validate_success() {
@@ -121,7 +118,6 @@ async fn setup_and_create_graphs() -> (PegInGraph, PegOutGraph, OutPoint) {
             amount,
         },
         &config.commitment_secrets,
-        get_lock_scripts_cached,
     );
 
     (peg_in_graph, peg_out_graph, peg_in_outpoint)


### PR DESCRIPTION
TODOs

- [x] fix `test_sync`: Failed to push: Failed to save data file
- [x] don't write to cache if already exist
- [x] investigate why mock-up winternitz public key is not the same or use other UID
- [x] compression
- [x] 20 limits of total cache file created