### PR TITLE
Clean up Esplora URL handling

### DIFF
--- a/bridge/src/client/cli/client_command.rs
+++ b/bridge/src/client/cli/client_command.rs
@@ -56,6 +56,7 @@ impl ClientCommand {
         }
 
         let bitvm_client = BitVMClient::new(
+            None,
             source_network,
             destination_network,
             &n_of_n_public_keys,

--- a/bridge/src/client/cli/query_command.rs
+++ b/bridge/src/client/cli/query_command.rs
@@ -3,7 +3,6 @@ use bitcoin::{Amount, Network, OutPoint, PublicKey, XOnlyPublicKey};
 use clap::{arg, ArgMatches, Command};
 use core::str::FromStr;
 
-pub const ESPLORA_FUNDING_URL: &str = "https://faucet.mutinynet.com/";
 use super::{
     query_response::{Response, ResponseStatus},
     validation::{validate, ArgType},
@@ -19,6 +18,9 @@ use crate::{
     scripts::generate_pay_to_pubkey_script_address,
     transactions::base::Input,
 };
+
+// TODO: This is Alpen signet. Verify what we need here and update accordingly.
+const ESPLORA_URL: &str = "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
 
 pub struct QueryCommand {
     client: BitVMClient,
@@ -41,6 +43,7 @@ impl QueryCommand {
         let n_of_n_public_keys: Vec<PublicKey> = vec![verifier_0_public_key];
 
         let bitvm_client = BitVMClient::new(
+            Some(ESPLORA_URL),
             source_network,
             destination_network,
             &n_of_n_public_keys,
@@ -554,7 +557,7 @@ impl QueryCommand {
                     "Fund {:?} with {} sats at {}",
                     funding_utxo_address,
                     input_value.to_sat(),
-                    ESPLORA_FUNDING_URL,
+                    ESPLORA_URL,
                 );
             });
         OutPoint {

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -66,7 +66,8 @@ use super::{
     },
 };
 
-const ESPLORA_URL: &str = "http://localhost:8094/regtest/api/";
+// TODO: Update for production.
+const ESPLORA_URL: &str = "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
 const TEN_MINUTES: u64 = 10 * 60;
 
 pub type UtxoSet = HashMap<OutPoint, Height>;
@@ -126,6 +127,7 @@ pub struct BitVMClient {
 impl BitVMClient {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
+        esplora_url: Option<&str>,
         source_network: Network,
         destination_network: DestinationNetwork,
         n_of_n_public_keys: &[PublicKey],
@@ -202,7 +204,7 @@ impl BitVMClient {
         let chain_adaptor = Chain::new();
 
         Self {
-            esplora: Builder::new(ESPLORA_URL)
+            esplora: Builder::new(esplora_url.unwrap_or(ESPLORA_URL))
                 .build_async()
                 .expect("Could not build esplora client"),
 

--- a/bridge/src/utils.rs
+++ b/bridge/src/utils.rs
@@ -9,8 +9,8 @@ use bitcoin_script::{script, Script};
 use bitvm::{bigint::BigIntImpl, pseudo::NMUL};
 use serde::{Deserialize, Serialize};
 
-const NUM_BLOCKS_REGTEST: u32 = 3;
-const NUM_BLOCKS_TESTNET: u32 = 3;
+const NUM_BLOCKS_REGTEST: u32 = 2;
+const NUM_BLOCKS_TESTNET: u32 = 2;
 
 pub fn num_blocks_per_network(network: Network, mainnet_num_blocks: u32) -> u32 {
     match network {

--- a/bridge/tests/bridge/assert/helper.rs
+++ b/bridge/tests/bridge/assert/helper.rs
@@ -83,9 +83,9 @@ pub async fn create_and_mine_assert_initial_tx(
 
     let tx = assert_initial_tx.finalize();
     let tx_id = tx.compute_txid();
+    println!("Txid: {:?}", tx_id);
     wait_timelock_expiry(network, Some("kick off 2 connector b")).await;
     let result = esplora.broadcast(&tx).await;
-    println!("Txid: {:?}", tx_id);
     println!("Assert initial tx result: {:?}\n", result);
     assert!(result.is_ok());
 

--- a/bridge/tests/bridge/faucet.rs
+++ b/bridge/tests/bridge/faucet.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, process::Command, time::Duration};
 use tokio::time::sleep;
 
-use crate::bridge::helper::{ESPLORA_FUNDING_URL, TX_WAIT_TIME};
+use crate::bridge::helper::{ALPEN_SIGNET_ESPLORA_URL, TX_WAIT_TIME};
 
 const ESPLORA_RETRIES: usize = 5;
 const ESPLORA_RETRY_WAIT_TIME: u64 = 10;
@@ -152,12 +152,12 @@ impl Faucet {
             "Funding {:?} with {} sats at {}",
             address,
             amount.to_sat(),
-            ESPLORA_FUNDING_URL,
+            ALPEN_SIGNET_ESPLORA_URL,
         );
 
         Self::http_post(
             &self.client,
-            format!("{}api/onchain", ESPLORA_FUNDING_URL),
+            format!("{}api/onchain", ALPEN_SIGNET_ESPLORA_URL),
             payload,
         )
         .await

--- a/bridge/tests/bridge/helper.rs
+++ b/bridge/tests/bridge/helper.rs
@@ -80,7 +80,6 @@ pub async fn wait_for_confirmation() {
 
 pub async fn wait_timelock_expiry(network: Network, timelock_name: Option<&str>) {
     let timeout = Duration::from_secs(TX_WAIT_TIME * num_blocks_per_network(network, 0) as u64);
-    let a = DURATION_COLOR;
     println!(
         "Waiting {DURATION_COLOR}{:?}{RESET_COLOR} {} to timeout ...",
         timeout,

--- a/bridge/tests/bridge/helper.rs
+++ b/bridge/tests/bridge/helper.rs
@@ -29,13 +29,32 @@ use bitvm::{
 use rand::{RngCore, SeedableRng};
 use tokio::time::sleep;
 
-pub const TX_WAIT_TIME: u64 = 5; // in seconds
-pub const ESPLORA_FUNDING_URL: &str = "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
+pub const TX_WAIT_TIME: u64 = 8; // In seconds. Must be >= expected block time.
+const REGTEST_ESPLORA_URL: &str = "http://localhost:8094/regtest/api/";
+pub const ALPEN_SIGNET_ESPLORA_URL: &str =
+    "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
+
 pub const ESPLORA_RETRIES: usize = 3;
 pub const ESPLORA_RETRY_WAIT_TIME: u64 = 5;
 
+pub fn get_esplora_url(network: Network) -> &'static str {
+    match network {
+        Network::Regtest => REGTEST_ESPLORA_URL,
+        _ => ALPEN_SIGNET_ESPLORA_URL,
+    }
+}
+
+/// Returns expected block time for the given network in seconds.
+pub fn network_block_time(network: Network) -> u64 {
+    match network {
+        Network::Regtest => 8, // Refer to block interval in regtest/block-generator.sh
+        _ => 35, // Testnet, signet. See https://mempool0713bb23.devnet-annapurna.stratabtc.org/
+    }
+}
+
 pub const TX_RELAY_FEE_CHECK_FAIL_MSG: &str =
     "Output sum should be equal to initial amount, check MIN_RELAY_FEE_* definitions?";
+
 pub fn check_tx_output_sum(input_amount_without_relay_fee: u64, tx: &Transaction) {
     assert_eq!(
         input_amount_without_relay_fee,
@@ -57,11 +76,11 @@ pub async fn wait_for_confirmation() {
 pub async fn wait_timelock_expiry(network: Network, timelock_name: Option<&str>) {
     let timeout = Duration::from_secs(TX_WAIT_TIME * num_blocks_per_network(network, 0) as u64);
     println!(
-        "Waiting \x1b[37;41m{:?}\x1b[0m {} to timeout ...",
+        "Waiting \x1b[37;41m{:?}\x1b[0m{} to timeout ...",
         timeout,
         match timelock_name {
-            Some(timelock_name) => format!("for {}", timelock_name),
-            None => "".to_string(),
+            Some(timelock_name) => format!(" for {}", timelock_name),
+            None => String::new(),
         }
     );
     sleep(timeout).await;
@@ -80,7 +99,7 @@ pub async fn generate_stub_outpoint(
                 "Fund {:?} with {} sats at {}",
                 funding_utxo_address,
                 input_value.to_sat(),
-                ESPLORA_FUNDING_URL,
+                ALPEN_SIGNET_ESPLORA_URL,
             );
         });
     OutPoint {
@@ -102,7 +121,7 @@ pub async fn generate_stub_outpoints(
                 "Fund {:?} with {} sats at {}",
                 funding_utxo_address,
                 input_value.to_sat(),
-                ESPLORA_FUNDING_URL,
+                ALPEN_SIGNET_ESPLORA_URL,
             );
         });
     funding_utxos
@@ -132,7 +151,7 @@ pub async fn verify_funding_inputs(client: &BitVMClient, funding_inputs: &Vec<(&
             "Fund {:?} with {} sats at {}",
             input_to_fund.0,
             input_to_fund.1.to_sat(),
-            ESPLORA_FUNDING_URL,
+            ALPEN_SIGNET_ESPLORA_URL,
         );
     }
     if !inputs_to_fund.is_empty() {

--- a/bridge/tests/bridge/setup.rs
+++ b/bridge/tests/bridge/setup.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use bitcoin::{Network, PublicKey};
 
-use super::helper::{get_correct_proof, get_incorrect_proof, get_intermediate_variables_cached};
+use super::helper::{
+    get_correct_proof, get_esplora_url, get_incorrect_proof, get_intermediate_variables_cached,
+};
 use bridge::{
     client::client::BitVMClient,
     commitments::CommitmentMessageId,
@@ -202,6 +204,7 @@ pub async fn setup_test() -> SetupConfig {
         WithdrawerContext::new(source_network, WITHDRAWER_SECRET, &n_of_n_public_keys);
 
     let client_0 = BitVMClient::new(
+        Some(get_esplora_url(source_network)),
         source_network,
         destination_network,
         &n_of_n_public_keys,
@@ -215,6 +218,7 @@ pub async fn setup_test() -> SetupConfig {
     .await;
 
     let client_1 = BitVMClient::new(
+        Some(get_esplora_url(source_network)),
         source_network,
         destination_network,
         &n_of_n_public_keys,


### PR DESCRIPTION
- Synchronize UTXO timelocks to test network block time (fixes the 'non-BIP68-final' errors)
- Reduce testnet block wait time