### PR TITLE
Couple test tx wait time with regtest scripts

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+# Desired block time in seconds for the regtest network
+REGTEST_BLOCK_TIME=8

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,0 @@
-# Desired block time in seconds for the regtest network
-REGTEST_BLOCK_TIME=8

--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,0 +1,2 @@
+# Desired block time in seconds for the regtest network
+REGTEST_BLOCK_TIME=8

--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,2 +1,2 @@
 # Desired block time in seconds for the regtest network
-REGTEST_BLOCK_TIME=8
+REGTEST_BLOCK_TIME=5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,6 +97,7 @@ jobs:
 #        BRIDGE_AWS_REGION: ap-southeast-1
 #        BRIDGE_AWS_BUCKET: bitvm
 #      run: |
+#        cp .env.test.sample .env.test
 #        cd regtest
 #        ./install.sh <<< "."
 #        ./start.sh

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target/
 
 # Ignore .env files
 .env
+.env.test
 
 # Added by cargo
 

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -105,6 +105,7 @@ pub struct BitVMClientPrivateData {
 
 pub struct BitVMClient {
     pub esplora: AsyncClient,
+    pub source_network: Network,
 
     depositor_context: Option<DepositorContext>,
     operator_context: Option<OperatorContext>,
@@ -207,6 +208,7 @@ impl BitVMClient {
             esplora: Builder::new(esplora_url.unwrap_or(ESPLORA_URL))
                 .build_async()
                 .expect("Could not build esplora client"),
+            source_network,
 
             depositor_context,
             operator_context,

--- a/bridge/tests/bridge/assert/assert.rs
+++ b/bridge/tests/bridge/assert/assert.rs
@@ -12,7 +12,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, generate_stub_outpoint, wait_timelock_expiry},
+    helper::{check_tx_output_sum, generate_stub_outpoint, wait_for_timelock_expiry},
     setup::{setup_test_full, ONE_HUNDRED},
 };
 
@@ -77,7 +77,7 @@ async fn test_assert_tx_success() {
             .collect::<Vec<u64>>()
     );
     check_tx_output_sum(ONE_HUNDRED, &tx);
-    wait_timelock_expiry(config.network, Some("kick off 2 connector b")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector b")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Assert tx result: {:?}\n", result);

--- a/bridge/tests/bridge/assert/assert_commits.rs
+++ b/bridge/tests/bridge/assert/assert_commits.rs
@@ -18,7 +18,7 @@ use num_traits::ToPrimitive;
 use crate::bridge::{
     assert::helper::fund_create_and_mine_assert_initial_tx,
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, get_reward_amount, wait_timelock_expiry},
+    helper::{check_tx_output_sum, get_reward_amount, wait_for_timelock_expiry},
     setup::{setup_test_full, ONE_HUNDRED},
 };
 
@@ -132,7 +132,7 @@ async fn test_assert_commits_tx_success() {
     // println!("Assert commit 1 total size: {}, virtual size: {}", assert_commit1_tx.total_size(), assert_commit1_tx.vsize());
     // println!("Assert commit 2 total size: {}, virtual size: {}", assert_commit2_tx.total_size(), assert_commit2_tx.vsize());
 
-    wait_timelock_expiry(config.network, Some("assert initial connector 4")).await;
+    wait_for_timelock_expiry(config.network, Some("assert initial connector 4")).await;
 
     let commit1_result = config.client_0.esplora.broadcast(&assert_commit1_tx).await;
     println!("Txid: {:?}", assert_commit1_tx.compute_txid());

--- a/bridge/tests/bridge/assert/helper.rs
+++ b/bridge/tests/bridge/assert/helper.rs
@@ -15,7 +15,7 @@ use esplora_client::AsyncClient;
 
 use crate::bridge::{
     faucet::Faucet,
-    helper::{generate_stub_outpoint, wait_timelock_expiry},
+    helper::{generate_stub_outpoint, wait_for_timelock_expiry},
     setup::SetupConfigFull,
 };
 
@@ -84,7 +84,7 @@ pub async fn create_and_mine_assert_initial_tx(
     let tx = assert_initial_tx.finalize();
     let tx_id = tx.compute_txid();
     println!("Txid: {:?}", tx_id);
-    wait_timelock_expiry(network, Some("kick off 2 connector b")).await;
+    wait_for_timelock_expiry(network, Some("kick off 2 connector b")).await;
     let result = esplora.broadcast(&tx).await;
     println!("Assert initial tx result: {:?}\n", result);
     assert!(result.is_ok());

--- a/bridge/tests/bridge/client/fee.rs
+++ b/bridge/tests/bridge/client/fee.rs
@@ -32,7 +32,7 @@ use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
         check_tx_output_sum, find_peg_in_graph_by_peg_out, generate_stub_outpoint,
-        get_incorrect_proof, get_reward_amount, wait_for_confirmation, wait_timelock_expiry,
+        get_incorrect_proof, get_reward_amount, wait_for_confirmation, wait_for_timelock_expiry,
     },
     mock::chain::mock::MockAdaptor,
     setup::{setup_test, INITIAL_AMOUNT, ONE_HUNDRED},
@@ -84,7 +84,7 @@ async fn test_peg_in_fees() {
         .await;
 
     let peg_in_graph = get_peg_in_graph_mut(&mut config.client_0, peg_in_graph_id.clone());
-    wait_timelock_expiry(config.network, Some("peg-in deposit connector z")).await;
+    wait_for_timelock_expiry(config.network, Some("peg-in deposit connector z")).await;
     let peg_in_confirm_tx = peg_in_graph.confirm(&esplora_client).await.unwrap();
     check_tx_output_sum(
         INITIAL_AMOUNT + max(MIN_RELAY_FEE_PEG_IN_CONFIRM, MIN_RELAY_FEE_PEG_IN_REFUND)
@@ -165,7 +165,7 @@ async fn test_peg_out_fees() {
         .broadcast_peg_in_deposit(&peg_in_graph_id)
         .await
         .expect("Failed to broadcast peg-in deposit");
-    wait_timelock_expiry(config.network, Some("peg-in deposit connector z")).await;
+    wait_for_timelock_expiry(config.network, Some("peg-in deposit connector z")).await;
 
     println!(
         "musig2 signing for peg-in: {} and its related peg-out: {}",
@@ -248,7 +248,7 @@ async fn test_peg_out_fees() {
         .unwrap();
     check_tx_output_sum(ONE_HUNDRED, &peg_out_tx);
     let peg_out_result = esplora_client.broadcast(&peg_out_tx).await;
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
     println!("peg out tx result: {:?}\n", peg_out_result);
     assert!(peg_out_result.is_ok());
 
@@ -261,7 +261,7 @@ async fn test_peg_out_fees() {
         &peg_out_confirm_tx,
     );
     let peg_out_confirm_result = esplora_client.broadcast(&peg_out_confirm_tx).await;
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
     println!("peg out confirm tx result: {:?}\n", peg_out_confirm_result);
     assert!(peg_out_confirm_result.is_ok());
 
@@ -284,7 +284,7 @@ async fn test_peg_out_fees() {
         &kick_off_1_tx,
     );
     let kick_off_1_result = esplora_client.broadcast(&kick_off_1_tx).await;
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
     println!(
         "kick off 1 tx result: {:?}, {:?}\n",
         kick_off_1_result,
@@ -302,7 +302,7 @@ async fn test_peg_out_fees() {
         .unwrap();
     check_tx_output_sum(DUST_AMOUNT, &start_time_tx);
 
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let start_time_timeout_tx = peg_out_graph
         .start_time_timeout(
             &esplora_client,
@@ -403,8 +403,8 @@ async fn test_peg_out_fees() {
         kick_off_2_result,
         kick_off_2_tx.compute_txid()
     );
-    wait_for_confirmation().await;
-    wait_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
+    wait_for_confirmation(config.network).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
 
     let take_1_tx = peg_out_graph.take_1(&esplora_client).await.unwrap();
     // minus 1 dust from kick off 1 connector 2
@@ -443,7 +443,7 @@ async fn test_peg_out_fees() {
         assert_initial_result,
         assert_initial_tx.compute_txid()
     );
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
 
     let assert_commit1_tx = peg_out_graph
         .assert_commit_1(&esplora_client, &config.commitment_secrets)
@@ -457,7 +457,7 @@ async fn test_peg_out_fees() {
         assert_commit1_result,
         assert_commit1_tx.compute_txid()
     );
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
 
     let assert_commit2_tx = peg_out_graph
         .assert_commit_2(&esplora_client, &config.commitment_secrets)
@@ -471,7 +471,7 @@ async fn test_peg_out_fees() {
         assert_commit2_result,
         assert_commit2_tx.compute_txid()
     );
-    wait_for_confirmation().await;
+    wait_for_confirmation(config.network).await;
 
     let assert_final_tx = peg_out_graph.assert_final(&esplora_client).await.unwrap();
     // minus 2 dust from kick off 1, 1 dust from kick off 2
@@ -485,8 +485,8 @@ async fn test_peg_out_fees() {
         assert_final_result,
         assert_final_tx.compute_txid()
     );
-    wait_for_confirmation().await;
-    wait_timelock_expiry(config.network, Some("assert final connector 4")).await;
+    wait_for_confirmation(config.network).await;
+    wait_for_timelock_expiry(config.network, Some("assert final connector 4")).await;
 
     let take_2_tx = peg_out_graph
         .take_2(&esplora_client, &config.operator_context)

--- a/bridge/tests/bridge/client/musig2_peg_in.rs
+++ b/bridge/tests/bridge/client/musig2_peg_in.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use bitcoin::Amount;
 
 use bridge::{
@@ -8,11 +6,10 @@ use bridge::{
 };
 
 use serial_test::serial;
-use tokio::time::sleep;
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{generate_stub_outpoint, TX_WAIT_TIME},
+    helper::{generate_stub_outpoint, wait_for_confirmation_with_message},
     setup::{setup_test, INITIAL_AMOUNT},
 };
 
@@ -100,13 +97,7 @@ async fn test_musig2_peg_in() {
     println!("Operator: Reading state from remote...");
     depositor_operator_verifier_0_client.sync().await;
 
-    let timeout = Duration::from_secs(TX_WAIT_TIME);
-    println!(
-        "Waiting {:?} for peg-in deposit transaction to be mined...",
-        timeout
-    );
-    sleep(timeout).await; // TODO: Replace this with a 'wait x amount of time till tx is mined' routine.
-                          // See the relevant TODO in PegInGraph::confirm().
+    wait_for_confirmation_with_message(config.network, Some("peg-in deposit tx")).await;
 
     println!("Depositor: Mining peg in confirm...");
     depositor_operator_verifier_0_client

--- a/bridge/tests/bridge/client/musig2_peg_out.rs
+++ b/bridge/tests/bridge/client/musig2_peg_out.rs
@@ -104,7 +104,7 @@ async fn test_musig2_peg_out_take_2() {
     )
     .await;
 
-    eprintln!("Broadcasting take 2...");
+    println!("Broadcasting take 2...");
     depositor_operator_verifier_0_client.sync().await;
     depositor_operator_verifier_0_client
         .broadcast_take_2(&peg_out_graph_id)
@@ -318,7 +318,7 @@ async fn broadcast_transactions_from_peg_out_graph(
     with_challenge_tx: bool,
     _with_assert_tx: bool,
 ) {
-    eprintln!("Broadcasting kick-off 1...");
+    println!("Broadcasting kick-off 1...");
     client.sync().await;
     client
         .broadcast_kick_off_1(peg_out_graph_id)
@@ -328,7 +328,7 @@ async fn broadcast_transactions_from_peg_out_graph(
     wait_for_confirmation_with_message(client.source_network, Some("peg-out kick-off 1 tx")).await;
 
     if with_kick_off_2_tx {
-        eprintln!("Broadcasting start time...");
+        println!("Broadcasting start time...");
         client
             .broadcast_start_time(peg_out_graph_id)
             .await
@@ -337,7 +337,7 @@ async fn broadcast_transactions_from_peg_out_graph(
         wait_for_confirmation_with_message(client.source_network, Some("peg-out start time tx"))
             .await;
 
-        eprintln!("Broadcasting kick-off 2...");
+        println!("Broadcasting kick-off 2...");
         client
             .broadcast_kick_off_2(peg_out_graph_id)
             .await
@@ -371,7 +371,7 @@ async fn broadcast_transactions_from_peg_out_graph(
             amount: challenge_input_amount,
             script: &generate_pay_to_pubkey_script(&depositor_context.depositor_public_key),
         };
-        eprintln!("Broadcasting challenge...");
+        println!("Broadcasting challenge...");
         client
             .broadcast_challenge(
                 peg_out_graph_id,
@@ -387,7 +387,7 @@ async fn broadcast_transactions_from_peg_out_graph(
 
     // TODO: uncomment after assert txs are done
     // if with_assert_tx {
-    //     eprintln!("Broadcasting assert...");
+    //     println!("Broadcasting assert...");
     //     client.broadcast_assert(&peg_out_graph_id).await;
 
     //     wait_for_confirmation_with_message(client.source_network, Some("peg-out assert tx")).await;
@@ -438,7 +438,7 @@ async fn create_peg_out_graph() -> (
     )
     .await;
 
-    eprintln!("Creating peg-in graph...");
+    println!("Creating peg-in graph...");
     // create and complete peg-in graph
     let peg_in_graph_id = create_peg_in_graph(
         &mut depositor_operator_verifier_0_client,
@@ -449,7 +449,7 @@ async fn create_peg_out_graph() -> (
     )
     .await;
 
-    eprintln!("Creating peg-out graph...");
+    println!("Creating peg-out graph...");
     depositor_operator_verifier_0_client.sync().await;
     let peg_out_graph_id = depositor_operator_verifier_0_client.create_peg_out_graph(
         &peg_in_graph_id,
@@ -460,21 +460,21 @@ async fn create_peg_out_graph() -> (
         config.commitment_secrets,
     );
 
-    eprintln!("Verifier 0 push peg-out nonces");
+    println!("Verifier 0 push peg-out nonces");
     depositor_operator_verifier_0_client.push_verifier_nonces(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
-    eprintln!("Verifier 1 push peg-out nonces");
+    println!("Verifier 1 push peg-out nonces");
     verifier_1_client.sync().await;
     verifier_1_client.push_verifier_nonces(&peg_out_graph_id);
     verifier_1_client.flush().await;
 
-    eprintln!("Verifier 0 pre-sign peg-out");
+    println!("Verifier 0 pre-sign peg-out");
     depositor_operator_verifier_0_client.sync().await;
     depositor_operator_verifier_0_client.push_verifier_signature(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
-    eprintln!("Verifier 1 pre-sign peg-out");
+    println!("Verifier 1 pre-sign peg-out");
     verifier_1_client.sync().await;
     verifier_1_client.push_verifier_signature(&peg_out_graph_id);
     verifier_1_client.flush().await;
@@ -608,7 +608,7 @@ async fn simulate_peg_out_from_l2(
         amount: peg_in_confirm_amount,
     };
 
-    eprintln!("Broadcasting peg out...");
+    println!("Broadcasting peg out...");
     client
         .broadcast_peg_out(peg_out_graph_id, input)
         .await
@@ -616,7 +616,7 @@ async fn simulate_peg_out_from_l2(
 
     wait_for_confirmation_with_message(client.source_network, Some("peg-out tx")).await;
 
-    eprintln!("Broadcasting peg out confirm...");
+    println!("Broadcasting peg out confirm...");
     client
         .broadcast_peg_out_confirm(peg_out_graph_id)
         .await

--- a/bridge/tests/bridge/e2e/e2e_l2_ui.rs
+++ b/bridge/tests/bridge/e2e/e2e_l2_ui.rs
@@ -106,7 +106,7 @@ async fn test_e2e_1_simulate_peg_out() {
         outpoint: operator_funding_outpoint,
         amount: peg_out_chain_event.amount,
     };
-    eprintln!("Broadcasting peg out...");
+    println!("Broadcasting peg out...");
     operator_client
         .broadcast_peg_out(peg_out_graph.id(), input)
         .await
@@ -195,7 +195,7 @@ async fn create_graph() -> (
         Ok(depositor_evm_address) => depositor_evm_address,
         Err(_) => config.depositor_evm_address,
     };
-    eprintln!("Creating peg-in graph...");
+    println!("Creating peg-in graph...");
     // create and complete peg-in graph
     let peg_in_graph_id = create_peg_in_graph(
         &mut depositor_operator_verifier_0_client,
@@ -207,7 +207,7 @@ async fn create_graph() -> (
     .await;
 
     depositor_operator_verifier_0_client.sync().await;
-    eprintln!("Creating peg-out graph...");
+    println!("Creating peg-out graph...");
     let peg_out_graph_id = depositor_operator_verifier_0_client.create_peg_out_graph(
         &peg_in_graph_id,
         Input {
@@ -217,21 +217,21 @@ async fn create_graph() -> (
         config.commitment_secrets,
     );
 
-    eprintln!("Verifier 0 push peg-out nonces");
+    println!("Verifier 0 push peg-out nonces");
     depositor_operator_verifier_0_client.push_verifier_nonces(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
-    eprintln!("Verifier 1 push peg-out nonces");
+    println!("Verifier 1 push peg-out nonces");
     verifier_1_client.sync().await;
     verifier_1_client.push_verifier_nonces(&peg_out_graph_id);
     verifier_1_client.flush().await;
 
-    eprintln!("Verifier 0 pre-sign peg-out");
+    println!("Verifier 0 pre-sign peg-out");
     depositor_operator_verifier_0_client.sync().await;
     depositor_operator_verifier_0_client.push_verifier_signature(&peg_out_graph_id);
     depositor_operator_verifier_0_client.flush().await;
 
-    eprintln!("Verifier 1 pre-sign peg-out");
+    println!("Verifier 1 pre-sign peg-out");
     verifier_1_client.sync().await;
     verifier_1_client.push_verifier_signature(&peg_out_graph_id);
     verifier_1_client.flush().await;
@@ -304,7 +304,7 @@ async fn create_peg_in_graph(
 //     with_challenge_tx: bool,
 //     with_assert_tx: bool,
 // ) {
-//     eprintln!("Broadcasting kick-off 1...");
+//     println!("Broadcasting kick-off 1...");
 //     client.sync().await;
 //     client.broadcast_kick_off_1(&peg_out_graph_id).await;
 
@@ -313,13 +313,13 @@ async fn create_peg_in_graph(
 //     sleep(Duration::from_secs(TX_WAIT_TIME)).await;
 
 //     if with_kick_off_2_tx {
-//         eprintln!("Broadcasting start time...");
+//         println!("Broadcasting start time...");
 //         client.broadcast_start_time(&peg_out_graph_id).await;
 
 //         println!("Waiting for peg-out start time tx...");
 //         sleep(Duration::from_secs(TX_WAIT_TIME)).await;
 
-//         eprintln!("Broadcasting kick-off 2...");
+//         println!("Broadcasting kick-off 2...");
 //         client.broadcast_kick_off_2(&peg_out_graph_id).await;
 
 //         println!("Waiting for peg-out kick-off 2 tx...");
@@ -348,7 +348,7 @@ async fn create_peg_in_graph(
 //             amount: challenge_input_amount,
 //             script: &generate_pay_to_pubkey_script(&depositor_context.depositor_public_key),
 //         };
-//         eprintln!("Broadcasting challenge...");
+//         println!("Broadcasting challenge...");
 //         client
 //             .broadcast_challenge(
 //                 &peg_out_graph_id,
@@ -362,7 +362,7 @@ async fn create_peg_in_graph(
 //     }
 
 //     if with_assert_tx {
-//         eprintln!("Broadcasting assert...");
+//         println!("Broadcasting assert...");
 //         client.broadcast_assert(&peg_out_graph_id).await;
 
 //         println!("Waiting for peg-out assert tx...");

--- a/bridge/tests/bridge/helper.rs
+++ b/bridge/tests/bridge/helper.rs
@@ -29,9 +29,16 @@ use bitvm::{
 use rand::{RngCore, SeedableRng};
 use tokio::time::sleep;
 
-use crate::bridge::{DURATION_COLOR, RESET_COLOR};
+const TEST_ENV_FILE: &str = ".env.test";
 
-pub const TX_WAIT_TIME: u64 = 8; // In seconds. Must be >= expected block time.
+fn load_u32_env_var_from_file(var: &str, file_name: &str) -> u32 {
+    dotenv::from_filename(file_name).ok();
+    dotenv::var(var)
+        .expect(format!("{var} not set in {file_name}").as_str())
+        .parse()
+        .expect(format!("Could not parse {var} specified in {file_name}").as_str())
+}
+
 pub const REGTEST_ESPLORA_URL: &str = "http://localhost:8094/regtest/api/";
 pub const ALPEN_SIGNET_ESPLORA_URL: &str =
     "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
@@ -47,12 +54,17 @@ pub fn get_esplora_url(network: Network) -> &'static str {
 }
 
 /// Returns expected block time for the given network in seconds.
-pub fn network_block_time(network: Network) -> u64 {
+fn network_block_time(network: Network) -> u32 {
     match network {
-        Network::Regtest => 8, // Refer to block interval in regtest/block-generator.sh
-        _ => 35, // Testnet, signet. See https://mempool0713bb23.devnet-annapurna.stratabtc.org/
+        Network::Regtest => load_u32_env_var_from_file("REGTEST_BLOCK_TIME", TEST_ENV_FILE),
+        _ => 35, // Testnet, signet. This value is for Alpen signet. See https://mempool0713bb23.devnet-annapurna.stratabtc.org/
     }
 }
+
+/// Provides a safe waiting duration in seconds for transaction confirmation on the specified network.
+/// This duration must be at least as long as the expected block time for that network.
+/// Returns network block time + 1 second for safety.
+fn tx_wait_time(network: Network) -> u64 { (network_block_time(network) + 1).into() }
 
 pub const TX_RELAY_FEE_CHECK_FAIL_MSG: &str =
     "Output sum should be equal to initial amount, check MIN_RELAY_FEE_* definitions?";
@@ -69,26 +81,43 @@ pub fn get_reward_amount(initial_amount: u64) -> u64 {
     initial_amount * REWARD_MULTIPLIER / REWARD_PRECISION
 }
 
-pub async fn wait_for_confirmation() {
-    let timeout = Duration::from_secs(TX_WAIT_TIME);
+const DURATION_COLOR: &str = "\x1b[30;46m"; // Black on cyan background
+const RESET_COLOR: &str = "\x1b[0m";
+
+async fn wait_with_message(timeout: Duration, message: &str) {
     println!(
-        "Waiting {DURATION_COLOR}{:?}{RESET_COLOR} for tx confirmation...",
-        timeout
+        "Waiting {DURATION_COLOR}{:?}{RESET_COLOR}{}...",
+        timeout, message
     );
     sleep(timeout).await;
 }
 
-pub async fn wait_timelock_expiry(network: Network, timelock_name: Option<&str>) {
-    let timeout = Duration::from_secs(TX_WAIT_TIME * num_blocks_per_network(network, 0) as u64);
-    println!(
-        "Waiting {DURATION_COLOR}{:?}{RESET_COLOR} {} to timeout ...",
-        timeout,
+pub async fn wait_for_confirmation_with_message(network: Network, message: Option<&str>) {
+    let timeout = Duration::from_secs(tx_wait_time(network));
+    let message = format!(" for {}", message.unwrap_or("tx confirmation"));
+
+    wait_with_message(timeout, message.as_str()).await;
+}
+
+pub async fn wait_for_confirmation(network: Network) {
+    wait_for_confirmation_with_message(network, None).await;
+}
+
+pub async fn wait_for_timelock_expiry(network: Network, timelock_name: Option<&str>) {
+    // Note that the extra 1 second from tx_wait_time() compounds here. Normally this will not be an issue.
+    // You'll just wait a couple seconds longer than the required number of blocks. However, if you need to
+    // wait for an exact number of seconds, consider using a simple sleep (or adding a sister helper function).
+    let timeout =
+        Duration::from_secs(tx_wait_time(network) * num_blocks_per_network(network, 0) as u64);
+    let message = format!(
+        " for{} timelock to expire",
         match timelock_name {
-            Some(timelock_name) => format!(" for {}", timelock_name),
+            Some(timelock_name) => format!(" {}", timelock_name),
             None => String::new(),
         }
     );
-    sleep(timeout).await;
+
+    wait_with_message(timeout, message.as_str()).await;
 }
 
 pub async fn generate_stub_outpoint(

--- a/bridge/tests/bridge/helper.rs
+++ b/bridge/tests/bridge/helper.rs
@@ -63,7 +63,7 @@ fn network_block_time(network: Network) -> u32 {
 
 /// Provides a safe waiting duration in seconds for transaction confirmation on the specified network.
 /// This duration must be at least as long as the expected block time for that network.
-/// Returns network block time + 1 second for safety.
+/// Returns network block time + 1 second to avoid race conditions.
 fn tx_wait_time(network: Network) -> u64 { (network_block_time(network) + 1).into() }
 
 pub const TX_RELAY_FEE_CHECK_FAIL_MSG: &str =

--- a/bridge/tests/bridge/helper.rs
+++ b/bridge/tests/bridge/helper.rs
@@ -29,16 +29,6 @@ use bitvm::{
 use rand::{RngCore, SeedableRng};
 use tokio::time::sleep;
 
-const TEST_ENV_FILE: &str = ".env.test";
-
-fn load_u32_env_var_from_file(var: &str, file_name: &str) -> u32 {
-    dotenv::from_filename(file_name).ok();
-    dotenv::var(var)
-        .expect(format!("{var} not set in {file_name}").as_str())
-        .parse()
-        .expect(format!("Could not parse {var} specified in {file_name}").as_str())
-}
-
 pub const REGTEST_ESPLORA_URL: &str = "http://localhost:8094/regtest/api/";
 pub const ALPEN_SIGNET_ESPLORA_URL: &str =
     "https://esploraapi53d3659b.devnet-annapurna.stratabtc.org/";
@@ -53,10 +43,23 @@ pub fn get_esplora_url(network: Network) -> &'static str {
     }
 }
 
+// Test environment config file and its variables
+const TEST_ENV_FILE: &str = ".env.test";
+const REGTEST_BLOCK_TIME: &str = "REGTEST_BLOCK_TIME";
+
+fn load_u32_env_var_from_file(var: &str, file_name: &str) -> u32 {
+    dotenv::from_filename(file_name)
+        .expect(format!("Please create a {file_name} file with the {var} variable").as_str());
+    dotenv::var(var)
+        .expect(format!("{var} variable missing in {file_name}").as_str())
+        .parse()
+        .expect(format!("Could not parse {var} specified in {file_name}").as_str())
+}
+
 /// Returns expected block time for the given network in seconds.
 fn network_block_time(network: Network) -> u32 {
     match network {
-        Network::Regtest => load_u32_env_var_from_file("REGTEST_BLOCK_TIME", TEST_ENV_FILE),
+        Network::Regtest => load_u32_env_var_from_file(REGTEST_BLOCK_TIME, TEST_ENV_FILE),
         _ => 35, // Testnet, signet. This value is for Alpen signet. See https://mempool0713bb23.devnet-annapurna.stratabtc.org/
     }
 }

--- a/bridge/tests/bridge/integration/peg_in/peg_in.rs
+++ b/bridge/tests/bridge/integration/peg_in/peg_in.rs
@@ -4,7 +4,7 @@ use bitcoin::{Amount, OutPoint};
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{generate_stub_outpoint, get_reward_amount, wait_timelock_expiry},
+    helper::{generate_stub_outpoint, get_reward_amount, wait_for_timelock_expiry},
     setup::{setup_test, SetupConfig, INITIAL_AMOUNT, ONE_HUNDRED},
 };
 use bridge::{
@@ -207,7 +207,7 @@ async fn test_peg_in_time_lock_surpassed() {
     let refund_txid = peg_in_refund_tx.compute_txid();
 
     // mine peg-in refund
-    wait_timelock_expiry(config.network, Some("peg-in deposit connector_z")).await;
+    wait_for_timelock_expiry(config.network, Some("peg-in deposit connector_z")).await;
     let refund_result = config.client_0.esplora.broadcast(&peg_in_refund_tx).await;
     println!("Peg-in Refund tx result: {:?}\n", refund_result);
     assert!(refund_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/disprove.rs
+++ b/bridge/tests/bridge/integration/peg_out/disprove.rs
@@ -23,7 +23,7 @@ use num_traits::ToPrimitive;
 use crate::bridge::{
     assert::helper::create_and_mine_assert_initial_tx,
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, verify_funding_inputs, wait_timelock_expiry},
+    helper::{check_tx_output_sum, verify_funding_inputs, wait_for_timelock_expiry},
     integration::peg_out::utils::create_and_mine_kick_off_2_tx,
     setup::{setup_test_full, INITIAL_AMOUNT},
 };
@@ -302,7 +302,7 @@ async fn test_disprove_success() {
 
     // mine disprove
     check_tx_output_sum(INITIAL_AMOUNT, &disprove_tx);
-    wait_timelock_expiry(config.network, Some("Assert connector 4")).await;
+    wait_for_timelock_expiry(config.network, Some("Assert connector 4")).await;
     let disprove_result = config.client_0.esplora.broadcast(&disprove_tx).await;
     println!("Disprove tx result: {disprove_result:?}");
     assert!(disprove_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/disprove_chain.rs
+++ b/bridge/tests/bridge/integration/peg_out/disprove_chain.rs
@@ -12,7 +12,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, verify_funding_inputs, wait_timelock_expiry},
+    helper::{check_tx_output_sum, verify_funding_inputs, wait_for_timelock_expiry},
     integration::peg_out::utils::create_and_mine_kick_off_2_tx,
     setup::{setup_test, INITIAL_AMOUNT},
 };
@@ -90,7 +90,7 @@ async fn test_disprove_chain_success() {
 
     check_tx_output_sum(INITIAL_AMOUNT, &disprove_chain_tx);
     // mine disprove chain
-    wait_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
     let disprove_chain_result = config.client_0.esplora.broadcast(&disprove_chain_tx).await;
     println!("disprove chain result: {:?}", disprove_chain_result);
     assert!(disprove_chain_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/kick_off_timeout.rs
+++ b/bridge/tests/bridge/integration/peg_out/kick_off_timeout.rs
@@ -15,7 +15,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, wait_timelock_expiry},
+    helper::{check_tx_output_sum, wait_for_timelock_expiry},
     integration::peg_out::utils::create_and_mine_kick_off_1_tx,
     setup::{setup_test, INITIAL_AMOUNT},
 };
@@ -105,7 +105,7 @@ async fn test_kick_off_timeout_success() {
 
     // mine kick-off timeout
     check_tx_output_sum(INITIAL_AMOUNT, &kick_off_timeout_tx);
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let kick_off_timeout_result = config
         .client_0
         .esplora

--- a/bridge/tests/bridge/integration/peg_out/start_time.rs
+++ b/bridge/tests/bridge/integration/peg_out/start_time.rs
@@ -12,7 +12,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, verify_funding_inputs, wait_timelock_expiry},
+    helper::{check_tx_output_sum, verify_funding_inputs, wait_for_timelock_expiry},
     integration::peg_out::utils::create_and_mine_kick_off_1_tx,
     setup::{setup_test, INITIAL_AMOUNT},
 };
@@ -77,7 +77,7 @@ async fn test_start_time_success() {
     // start time output should only have dust left
     check_tx_output_sum(DUST_AMOUNT, &start_time_tx);
     // mine start time timeout
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let start_time_result = config.client_0.esplora.broadcast(&start_time_tx).await;
     println!("Start time tx result: {:?}\n", start_time_result);
     assert!(start_time_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/start_time_timeout.rs
+++ b/bridge/tests/bridge/integration/peg_out/start_time_timeout.rs
@@ -15,7 +15,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, verify_funding_inputs, wait_timelock_expiry},
+    helper::{check_tx_output_sum, verify_funding_inputs, wait_for_timelock_expiry},
     integration::peg_out::utils::create_and_mine_kick_off_1_tx,
     setup::{setup_test, INITIAL_AMOUNT},
 };
@@ -112,7 +112,7 @@ async fn test_start_time_timeout_success() {
         &start_time_timeout_tx,
     );
     // mine start time timeout
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let start_time_timeout_result = config
         .client_0
         .esplora

--- a/bridge/tests/bridge/integration/peg_out/take_1.rs
+++ b/bridge/tests/bridge/integration/peg_out/take_1.rs
@@ -18,7 +18,7 @@ use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
         check_tx_output_sum, get_reward_amount, get_superblock_header, verify_funding_inputs,
-        wait_timelock_expiry,
+        wait_for_timelock_expiry,
     },
     integration::peg_out::utils::{
         create_and_mine_kick_off_1_tx, create_and_mine_peg_in_confirm_tx,
@@ -108,7 +108,7 @@ async fn test_take_1_success() {
     let kick_off_2_txid = kick_off_2_tx.compute_txid();
 
     // mine kick-off 2
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let kick_off_2_result = config.client_0.esplora.broadcast(&kick_off_2_tx).await;
     println!("Kick-off 2 result: {:?}\n", kick_off_2_result);
     assert!(kick_off_2_result.is_ok());
@@ -181,7 +181,7 @@ async fn test_take_1_success() {
     // addtional dust is from kick off 1 connector a
     check_tx_output_sum(ONE_HUNDRED + reward_amount + DUST_AMOUNT, &take_1_tx);
     // mine take 1
-    wait_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
     let take_1_result = config.client_0.esplora.broadcast(&take_1_tx).await;
     println!("TAKE 1 result: {:?}\n", take_1_result);
     assert!(take_1_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/take_2.rs
+++ b/bridge/tests/bridge/integration/peg_out/take_2.rs
@@ -15,7 +15,9 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, get_reward_amount, verify_funding_inputs, wait_timelock_expiry},
+    helper::{
+        check_tx_output_sum, get_reward_amount, verify_funding_inputs, wait_for_timelock_expiry,
+    },
     integration::peg_out::utils::{create_and_mine_assert_tx, create_and_mine_peg_in_confirm_tx},
     setup::{setup_test_full, INITIAL_AMOUNT, ONE_HUNDRED},
 };
@@ -142,7 +144,7 @@ async fn test_take_2_success() {
 
     // mine take 2
     check_tx_output_sum(INITIAL_AMOUNT + reward_amount + DUST_AMOUNT * 2, &take_2_tx);
-    wait_timelock_expiry(config.network, Some("assert connector 4")).await;
+    wait_for_timelock_expiry(config.network, Some("assert connector 4")).await;
     let take_2_result = config.client_0.esplora.broadcast(&take_2_tx).await;
     println!("Take 2 result: {:?}\n", take_2_result);
     assert!(take_2_result.is_ok());

--- a/bridge/tests/bridge/integration/peg_out/utils.rs
+++ b/bridge/tests/bridge/integration/peg_out/utils.rs
@@ -22,7 +22,9 @@ use bridge::{
     },
 };
 
-use crate::bridge::helper::{generate_stub_outpoint, get_superblock_header, wait_timelock_expiry};
+use crate::bridge::helper::{
+    generate_stub_outpoint, get_superblock_header, wait_for_timelock_expiry,
+};
 
 pub async fn create_and_mine_kick_off_1_tx(
     client: &BitVMClient,
@@ -114,7 +116,7 @@ pub async fn create_and_mine_kick_off_2_tx(
     let kick_off_2_txid = kick_off_2_tx.compute_txid();
 
     // mine kick-off 2 tx
-    wait_timelock_expiry(operator_context.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(operator_context.network, Some("kick off 1 connector 1")).await;
     let kick_off_2_result = client.esplora.broadcast(&kick_off_2_tx).await;
     println!("Kick off 2 tx result: {kick_off_2_result:?}");
     assert!(kick_off_2_result.is_ok());
@@ -158,7 +160,7 @@ pub async fn create_and_mine_assert_tx(
     let assert_txid = assert_tx.compute_txid();
 
     // mine assert tx
-    wait_timelock_expiry(verifier_0_context.network, Some("kick off 2 connector b")).await;
+    wait_for_timelock_expiry(verifier_0_context.network, Some("kick off 2 connector b")).await;
     let assert_result = client.esplora.broadcast(&assert_tx).await;
     assert!(assert_result.is_ok());
 

--- a/bridge/tests/bridge/kick_off_2/kick_off_2.rs
+++ b/bridge/tests/bridge/kick_off_2/kick_off_2.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use crate::{
     bridge::helper::{
-        check_tx_output_sum, get_reward_amount, get_superblock_header, wait_timelock_expiry,
+        check_tx_output_sum, get_reward_amount, get_superblock_header, wait_for_timelock_expiry,
     },
     bridge::setup::ONE_HUNDRED,
 };
@@ -67,7 +67,7 @@ async fn test_kick_off_2_tx_success() {
 
     let tx = kick_off_2_tx.finalize();
     check_tx_output_sum(reward_amount + DUST_AMOUNT, &tx);
-    wait_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
     let result: Result<(), esplora_client::Error> = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Kick Off 2 tx result: {:?}\n", result);

--- a/bridge/tests/bridge/kick_off_timeout/kick_off_timeout.rs
+++ b/bridge/tests/bridge/kick_off_timeout/kick_off_timeout.rs
@@ -13,7 +13,7 @@ use bridge::{
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
-        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_timelock_expiry,
+        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_for_timelock_expiry,
     },
     setup::{setup_test, ONE_HUNDRED},
 };
@@ -68,7 +68,7 @@ async fn test_kick_off_timeout_tx_success() {
 
     let tx = kick_off_timeout_tx.finalize();
     check_tx_output_sum(reward_amount, &tx);
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Kick off timeout result: {:?}\n", result);

--- a/bridge/tests/bridge/mod.rs
+++ b/bridge/tests/bridge/mod.rs
@@ -21,6 +21,3 @@ pub mod start_time_timeout;
 pub mod take_1;
 pub mod take_2;
 pub mod validate;
-
-const DURATION_COLOR: &str = "\x1b[30;46m"; // Black on cyan background
-const RESET_COLOR: &str = "\x1b[0m";

--- a/bridge/tests/bridge/peg_in/peg_in_refund.rs
+++ b/bridge/tests/bridge/peg_in/peg_in_refund.rs
@@ -10,7 +10,7 @@ use bridge::{
 
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
-    helper::{check_tx_output_sum, generate_stub_outpoint, wait_timelock_expiry},
+    helper::{check_tx_output_sum, generate_stub_outpoint, wait_for_timelock_expiry},
     setup::{setup_test, INITIAL_AMOUNT},
 };
 
@@ -40,7 +40,7 @@ async fn test_peg_in_refund_tx_success() {
 
     let tx = peg_in_refund_tx.finalize();
     check_tx_output_sum(INITIAL_AMOUNT, &tx);
-    wait_timelock_expiry(config.network, Some("peg in deposit connector z")).await;
+    wait_for_timelock_expiry(config.network, Some("peg in deposit connector z")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Peg in refund tx result: {:?}\n", result);

--- a/bridge/tests/bridge/start_time_timeout/start_time_timeout.rs
+++ b/bridge/tests/bridge/start_time_timeout/start_time_timeout.rs
@@ -15,7 +15,7 @@ use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
         check_tx_output_sum, generate_stub_outpoint, get_reward_amount, verify_funding_inputs,
-        wait_timelock_expiry,
+        wait_for_timelock_expiry,
     },
     setup::{setup_test, ONE_HUNDRED},
 };
@@ -86,7 +86,7 @@ async fn test_start_time_timeout_tx_success() {
 
     let tx = start_time_timeout_tx.finalize();
     check_tx_output_sum(reward_amount + DUST_AMOUNT, &tx);
-    wait_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 1 connector 1")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Start time timeout tx result: {:?}\n", result);

--- a/bridge/tests/bridge/take_1/take_1.rs
+++ b/bridge/tests/bridge/take_1/take_1.rs
@@ -13,7 +13,7 @@ use bridge::{
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
-        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_timelock_expiry,
+        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_for_timelock_expiry,
     },
     setup::{setup_test, ONE_HUNDRED},
 };
@@ -94,7 +94,7 @@ async fn test_take_1_tx_success() {
 
     let tx = take_1_tx.finalize();
     check_tx_output_sum(ONE_HUNDRED + reward_amount + DUST_AMOUNT * 2, &tx);
-    wait_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
+    wait_for_timelock_expiry(config.network, Some("kick off 2 connector 3")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Take 1 tx result: {:?}\n", result);

--- a/bridge/tests/bridge/take_2/take_2.rs
+++ b/bridge/tests/bridge/take_2/take_2.rs
@@ -13,7 +13,7 @@ use bridge::{
 use crate::bridge::{
     faucet::{Faucet, FaucetType},
     helper::{
-        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_timelock_expiry,
+        check_tx_output_sum, generate_stub_outpoint, get_reward_amount, wait_for_timelock_expiry,
     },
     setup::{setup_test_full, ONE_HUNDRED},
 };
@@ -99,7 +99,7 @@ async fn test_take_2_tx_success() {
 
     let tx = take_2_tx.finalize();
     check_tx_output_sum(ONE_HUNDRED + reward_amount + DUST_AMOUNT * 2, &tx);
-    wait_timelock_expiry(config.network, Some("assert connector 4")).await;
+    wait_for_timelock_expiry(config.network, Some("assert connector 4")).await;
     let result = config.client_0.esplora.broadcast(&tx).await;
     println!("Txid: {:?}", tx.compute_txid());
     println!("Take 2 tx result: {:?}\n", result);

--- a/regtest/block-generator.sh
+++ b/regtest/block-generator.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-        interval=8
+        # Load REGTEST_BLOCK_TIME
+        source ../.env.test
+
+        interval=$REGTEST_BLOCK_TIME
 else
         interval=$1
 fi

--- a/regtest/block-generator.sh
+++ b/regtest/block-generator.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
+CONFIG_FILE=../.env.test
 
 if [ -z "$1" ]; then
-        # Load REGTEST_BLOCK_TIME
-        source ../.env.test
+        # If no interval is specified, use the value from the config file
+        if [ -f $CONFIG_FILE ]; then
+                source $CONFIG_FILE
+
+                if [ -z "$REGTEST_BLOCK_TIME" ]; then
+                        echo "REGTEST_BLOCK_TIME variable missing in $CONFIG_FILE"
+                        exit 1
+                fi
+        else
+                echo "Please create a $CONFIG_FILE file with the REGTEST_BLOCK_TIME variable"
+                exit 1
+        fi
 
         interval=$REGTEST_BLOCK_TIME
 else


### PR DESCRIPTION
- Introduce `.env.test` file to configure regtest block time
- Update block generator script to read block interval from environment
- Modify helper functions to dynamically load block time from `.env.test`
- Add `source_network` field to `BitVMClient` to support network-specific configurations
- Refactor waiting functions in tests to use network-specific block times